### PR TITLE
knockout: run deferred tasks early

### DIFF
--- a/knockout-sortable.js
+++ b/knockout-sortable.js
@@ -157,6 +157,8 @@
                     // Force knockout to update
                     from.valueHasMutated();
                 }
+                // Force deferred tasks to run now, registering the removal
+                ko.tasks.runEarly();
                 // Insert the item on its new position
                 to().splice(newIndex, 0, itemVM);
                 // Make sure to tell knockout that we've modified the actual array.


### PR DESCRIPTION
If `ko.options.deferUpdates = true`, then updates to the UI don't happen immediately when you modify the viewModel. 
For the sortable binding, this means that after removing a moved item, it doesn't recreate it at the new position.
Calling `ko.tasks.runEarly` before re-inserting the item into the observableArray makes KO register the removal.

This is the fix proposed by @adriaanmeuris in RubaXa/Sortable#712
